### PR TITLE
create  workflow file to trigger Makefile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Trigger action for GOV.UK_co-cyber-security-external
+
+on:
+  workflow_dispatch:
+  push:
+    branches:    
+      - 'main'
+    paths:
+      - 'security.txt'
+      - 'thanks.txt'
+  schedule:
+     - cron: "0 2 * * MON-FRI" # Runs at 02:00 UTC
+      workflow_dispatch:
+jobs:
+ deploy-to-co-cyber-security-external:
+  # Trigger makefile for co-cyber-security-external
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be triggered and executed  as part of the job
+    steps:
+       - name: Show workflow_run
+    env:
+      co-cyber-security-external
+      name: Deploy to GOV.UK co-cyber-security-external
+      defaults:
+    run:
+        shell: bash
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: main
+    - run: |
+        cd main/
+
+      run: make deploy


### PR DESCRIPTION

**git push --set-upstream origin trigger_makefiles**

Enumerating objects: 6, done.
Counting objects: 100% (6/6), done.
Delta compression using up to 8 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (5/5), 863 bytes | 863.00 KiB/s, done.
Total 5 (delta 1), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (1/1), completed with 1 local object.
remote: 
remote: Create a pull request for 'trigger_makefiles' on GitHub by visiting:
remote:      https://github.com/alphagov/security.txt/pull/new/trigger_makefiles
remote: 
To github.com:alphagov/security.txt.git
 * [new branch]      trigger_makefiles -> trigger_makefiles
branch 'trigger_makefiles' set up to track 'origin/trigger_makefiles'.
**What problem does the pull request solve?**
(Describe why you’re making this change)

**Checklist**
 I’ve used the pull request template
 I've linked this PR to the relevant issue (if mission work)
 I’ve written unit tests for these changes (if code change)
 I’ve update the documentation in
 README.md
 Elsewhere (plese link)